### PR TITLE
Add new scripts to check if drawings need updates and code for new and improved fields

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,8 +28,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-note-with-leader.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -56,8 +56,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-callout-with-leader.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/ee63b9ee2302ab2088cf8fc0/w/0e48c187ddc923ea5a6dc36b/e/f2c479023e0c273f05f82d2d",
+                "--stack=staging"
             ]
         },
         {
@@ -98,8 +98,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-centerline.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-note.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
+                "--drawinguri=https://cad.onshape.com/documents/854e914aa52304e246a9eec9/w/abfdc05bfa1f41beddef6799/e/0bb00c2b35c0dad605592265",
                 "--stack=cad"
             ]
         },
@@ -28,8 +28,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-note-with-leader.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://cad.onshape.com/documents/854e914aa52304e246a9eec9/w/abfdc05bfa1f41beddef6799/e/0bb00c2b35c0dad605592265",
+                "--stack=cad"
             ]
         },
         {
@@ -42,8 +42,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-callout.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -56,7 +56,7 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-callout-with-leader.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/ee63b9ee2302ab2088cf8fc0/w/0e48c187ddc923ea5a6dc36b/e/f2c479023e0c273f05f82d2d",
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
                 "--stack=staging"
             ]
         },
@@ -70,8 +70,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-geometric-tolerance.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -84,8 +84,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-table.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -112,8 +112,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-point-to-point-linear-dimension.js",
             "args": [
-                "--drawinguri=https://demo-c.dev.onshape.com/documents/479cbd6fead91a4a641198f2/w/c1f63e254fda0e5dc1d8f354/e/c6177e4dddf9007dd15bbc1f",
-                "--stack=democ"
+                "--drawinguri=https://cad.onshape.com/documents/6d7058e0bd1b10f4966186c5/w/5877d326d938676cfd30433c/e/bea35ad394c20ec11b9be87e",
+                "--stack=cad"
             ]
         },
         {
@@ -126,8 +126,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-point-to-line-linear-dimension.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/ee63b9ee2302ab2088cf8fc0/w/0e48c187ddc923ea5a6dc36b/e/f2c479023e0c273f05f82d2d",
-                "--stack=staging"
+                "--drawinguri=https://cad.onshape.com/documents/6d7058e0bd1b10f4966186c5/w/5877d326d938676cfd30433c/e/bea35ad394c20ec11b9be87e",
+                "--stack=cad"
             ]
         },
         {
@@ -140,8 +140,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-line-to-line-linear-dimension.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -154,8 +154,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-aligned-linear-dimension.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -168,8 +168,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-line-to-line-angular-dimension.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -182,8 +182,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-three-point-angular-dimension.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -196,8 +196,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-radial-dimension.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -210,8 +210,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-diameter-dimension.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -224,8 +224,22 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-inspection-symbols.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/817e23922c032cf9009338eb/w/01142a1728d1bcb84bff6cfc/e/b3ccb5a55b65c63826c1c0e8",
+                "--stack=staging"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Detect if Update Needed",
+            "console": "integratedTerminal",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/.compiledjs/detect-update-needed.js",
+            "args": [
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/616523b0e7c1e69c8ab40aac",
+                "--stack=democ"
             ]
         },
         {
@@ -238,8 +252,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/edit-notes.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -252,8 +266,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/edit-dimension-attachments.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/66e3efbad7d5bab375522684/w/d481b96308ad2a5b7f261f0c/e/f0804a6511341d568ad63223",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         },
         {
@@ -266,7 +280,7 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/edit-dimension-text-positions.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/ee63b9ee2302ab2088cf8fc0/w/0e48c187ddc923ea5a6dc36b/e/f2c479023e0c273f05f82d2d",
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
                 "--stack=staging"
             ]
         },
@@ -280,8 +294,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/find-errors-in-drawing.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/6d7058e0bd1b10f4966186c5/w/5877d326d938676cfd30433c/e/bea35ad394c20ec11b9be87e",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
+                "--stack=staging"
             ]
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -112,8 +112,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-point-to-point-linear-dimension.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/479cbd6fead91a4a641198f2/w/c1f63e254fda0e5dc1d8f354/e/c6177e4dddf9007dd15bbc1f",
+                "--stack=democ"
             ]
         },
         {
@@ -126,8 +126,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-point-to-line-linear-dimension.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/3f7e7b5e2e6140fb84195b10/w/b2b41f2cbf04d2530cc8f205/e/749f074ef7c22c76b7e7f0f0",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/ee63b9ee2302ab2088cf8fc0/w/0e48c187ddc923ea5a6dc36b/e/f2c479023e0c273f05f82d2d",
+                "--stack=staging"
             ]
         },
         {
@@ -266,8 +266,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/edit-dimension-text-positions.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/66e3efbad7d5bab375522684/w/d481b96308ad2a5b7f261f0c/e/f0804a6511341d568ad63223",
-                "--stack=cad"
+                "--drawinguri=https://staging.dev.onshape.com/documents/ee63b9ee2302ab2088cf8fc0/w/0e48c187ddc923ea5a6dc36b/e/f2c479023e0c273f05f82d2d",
+                "--stack=staging"
             ]
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,8 +14,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-note.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/854e914aa52304e246a9eec9/w/abfdc05bfa1f41beddef6799/e/0bb00c2b35c0dad605592265",
-                "--stack=cad"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -28,8 +28,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-note-with-leader.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/854e914aa52304e246a9eec9/w/abfdc05bfa1f41beddef6799/e/0bb00c2b35c0dad605592265",
-                "--stack=cad"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -42,8 +42,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-callout.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -56,8 +56,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-callout-with-leader.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -70,8 +70,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-geometric-tolerance.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -84,8 +84,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-table.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -98,8 +98,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-centerline.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -112,8 +112,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-point-to-point-linear-dimension.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/6d7058e0bd1b10f4966186c5/w/5877d326d938676cfd30433c/e/bea35ad394c20ec11b9be87e",
-                "--stack=cad"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -126,8 +126,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-point-to-line-linear-dimension.js",
             "args": [
-                "--drawinguri=https://cad.onshape.com/documents/6d7058e0bd1b10f4966186c5/w/5877d326d938676cfd30433c/e/bea35ad394c20ec11b9be87e",
-                "--stack=cad"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -140,8 +140,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-line-to-line-linear-dimension.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -154,8 +154,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-aligned-linear-dimension.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -168,8 +168,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-line-to-line-angular-dimension.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -182,8 +182,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-three-point-angular-dimension.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -196,8 +196,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-radial-dimension.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -210,8 +210,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-diameter-dimension.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -224,8 +224,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-inspection-symbols.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/817e23922c032cf9009338eb/w/01142a1728d1bcb84bff6cfc/e/b3ccb5a55b65c63826c1c0e8",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -266,8 +266,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/edit-notes.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -280,8 +280,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/edit-dimension-attachments.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -294,8 +294,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/edit-dimension-text-positions.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         },
         {
@@ -308,8 +308,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/find-errors-in-drawing.js",
             "args": [
-                "--drawinguri=https://staging.dev.onshape.com/documents/b3cfb2d109cb7a2451d71da1/w/2560553b206382b541ceb481/e/ab58c1e00a7923a5b29e5a37",
-                "--stack=staging"
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--stack=democ"
             ]
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-note.js",
             "args": [
-                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/479cbd6fead91a4a641198f2/w/c1f63e254fda0e5dc1d8f354/e/29b32be038a4d89c7faeb1fb",
                 "--stack=democ"
             ]
         },
@@ -112,8 +112,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-point-to-point-linear-dimension.js",
             "args": [
-                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
-                "--stack=democ"
+                "--drawinguri=https://cad.onshape.com/documents/1289d5601707d8aca7270999/w/8aece27f8cbcb0b2553a5031/e/429fb9ca827bf61560120e08",
+                "--stack=cad"
             ]
         },
         {
@@ -168,7 +168,7 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/create-line-to-line-angular-dimension.js",
             "args": [
-                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/479cbd6fead91a4a641198f2/w/c1f63e254fda0e5dc1d8f354/e/29b32be038a4d89c7faeb1fb",
                 "--stack=democ"
             ]
         },
@@ -308,8 +308,8 @@
             ],
             "program": "${workspaceFolder}/.compiledjs/find-errors-in-drawing.js",
             "args": [
-                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/58eda968b0ce825d4ffeac79",
-                "--stack=democ"
+                "--drawinguri=https://cad.onshape.com/documents/6c66067eadfef1e3abaca519/v/eaba604a2af4d8cdd4c1fe54/e/ff72f81c3b3061f254aba9e7",
+                "--stack=cad"
             ]
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -231,12 +231,26 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Detect if Update Needed",
+            "name": "Detect If Single Drawing Needs Update",
             "console": "integratedTerminal",
             "skipFiles": [
                 "<node_internals>/**"
             ],
-            "program": "${workspaceFolder}/.compiledjs/detect-update-needed.js",
+            "program": "${workspaceFolder}/.compiledjs/detect-if-single-drawing-needs-update.js",
+            "args": [
+                "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/616523b0e7c1e69c8ab40aac",
+                "--stack=democ"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Detect If Workspace Contains Drawings Needing Update",
+            "console": "integratedTerminal",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/.compiledjs/detect-if-workspace-contains-drawings-needing-update.js",
             "args": [
                 "--drawinguri=https://demo-c.dev.onshape.com/documents/62ca01945f8ec38b9e245f3e/w/394fb53994fa4ba2e1d365e2/e/616523b0e7c1e69c8ab40aac",
                 "--stack=democ"

--- a/create-aligned-linear-dimension.ts
+++ b/create-aligned-linear-dimension.ts
@@ -37,7 +37,7 @@ if (validArgs) {
     /**
      * Retrieve a drawing view and some of its edges to get enough information to create the dimension
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
   
     if (viewToUse !== null) {
@@ -118,14 +118,19 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Create dimension succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
             responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
             const newDimLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
-        } else {
-          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+            console.log(`Create dimension succeeded and has a logicalId: ${newDimLogicalId}`);
+          } else {
+            console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');

--- a/create-aligned-linear-dimension.ts
+++ b/create-aligned-linear-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, DrawingObjectType, SnapPointType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, DrawingObjectType, SnapPointType, ModifyStatusResponseOutput, SingleRequestResultStatus} from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint } from './utils/drawingutils.js';
 
@@ -118,8 +118,15 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        console.log('Successfully created dimension.');
-        LOG.info(`Successfully created dimension.`);
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            // Success - logicalId of new dimension is available
+            const newDimLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
+        } else {
+          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');
         LOG.info('Create dimension failed waiting for modify to finish.');

--- a/create-aligned-linear-dimension.ts
+++ b/create-aligned-linear-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, DrawingObjectType, SnapPointType } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, DrawingObjectType, SnapPointType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint } from './utils/drawingutils.js';
 
@@ -116,8 +116,8 @@ if (validArgs) {
 
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
   
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully created dimension.');
         LOG.info(`Successfully created dimension.`);
       } else {

--- a/create-aligned-linear-dimension.ts
+++ b/create-aligned-linear-dimension.ts
@@ -120,7 +120,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
             const newDimLogicalId = responseOutput.results[0].logicalId;
             console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);

--- a/create-callout-with-leader.ts
+++ b/create-callout-with-leader.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, View2, SnapPointType, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, convertPointViewToPaper } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData } from './utils/drawingutils.js';
 
@@ -111,8 +111,8 @@ if (validArgs) {
        */
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
 
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully created callout with leader.');
         LOG.info(`Successfully created callout with leader.`);
       } else {

--- a/create-callout-with-leader.ts
+++ b/create-callout-with-leader.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, convertPointViewToPaper } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData } from './utils/drawingutils.js';
 
@@ -113,8 +113,15 @@ if (validArgs) {
 
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        console.log('Successfully created callout with leader.');
-        LOG.info(`Successfully created callout with leader.`);
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            // Success - logicalId of new callout is available
+            const newDimLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create callout with leader succeeded and new callout has a logicalId: ${newDimLogicalId}`);
+        } else {
+          console.log(`Create callout with leader failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       } else {
         console.log('Create callout with leader failed waiting for modify to finish.');
         LOG.info('Create callout with leader failed waiting for modify to finish.');

--- a/create-callout-with-leader.ts
+++ b/create-callout-with-leader.ts
@@ -36,7 +36,7 @@ if (validArgs) {
     /**
      * Retrieve a drawing view and some of its edges to get enough information to create the callout with leader
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
 
     if (viewToUse !== null) {
@@ -113,14 +113,19 @@ if (validArgs) {
 
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Create callout with leader succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
             responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new callout is available
-            const newDimLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Create callout with leader succeeded and new callout has a logicalId: ${newDimLogicalId}`);
-        } else {
-          console.log(`Create callout with leader failed. Response status code: ${responseOutput.statusCode}.`)
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create callout with leader succeeded and has a logicalId: ${newLogicalId}`);
+          } else {
+            console.log(`Create callout with leader failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Create callout with leader failed waiting for modify to finish.');

--- a/create-callout-with-leader.ts
+++ b/create-callout-with-leader.ts
@@ -115,7 +115,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new callout is available
             const newDimLogicalId = responseOutput.results[0].logicalId;
             console.log(`Create callout with leader succeeded and new callout has a logicalId: ${newDimLogicalId}`);

--- a/create-callout.ts
+++ b/create-callout.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, DrawingScriptArgs, validateBaseURLs, waitForModifyToFinish, parseDrawingScriptArgs, getRandomLocation } from './utils/drawingutils.js';
 
 const LOG = mainLog();
@@ -59,8 +59,15 @@ if (validArgs) {
   
     const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
     if (responseOutput) {
-      console.log('Successfully created callout.');
-      LOG.info(`Successfully created callout.`);
+      // Only 1 request was made - verify it succeeded
+      if (responseOutput.results.length == 1 &&
+          responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+          // Success - logicalId of new callout is available
+          const newDimLogicalId = responseOutput.results[0].logicalId;
+          console.log(`Create callout succeeded and new callout has a logicalId: ${newDimLogicalId}`);
+      } else {
+        console.log(`Create callout failed. Response status code: ${responseOutput.statusCode}.`)
+      }
     } else {
       console.log('Create callout failed waiting for modify to finish.');
       LOG.info('Create callout failed waiting for modify to finish.');

--- a/create-callout.ts
+++ b/create-callout.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, DrawingScriptArgs, validateBaseURLs, waitForModifyToFinish, parseDrawingScriptArgs, getRandomLocation } from './utils/drawingutils.js';
 
 const LOG = mainLog();
@@ -57,8 +57,8 @@ if (validArgs) {
   
     const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`,  requestBody) as BasicNode;
   
-    const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-    if (waitSucceeded) {
+    const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+    if (responseOutput) {
       console.log('Successfully created callout.');
       LOG.info(`Successfully created callout.`);
     } else {

--- a/create-callout.ts
+++ b/create-callout.ts
@@ -61,7 +61,7 @@ if (validArgs) {
     if (responseOutput) {
       // Only 1 request was made - verify it succeeded
       if (responseOutput.results.length == 1 &&
-          responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+          responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
           // Success - logicalId of new callout is available
           const newDimLogicalId = responseOutput.results[0].logicalId;
           console.log(`Create callout succeeded and new callout has a logicalId: ${newDimLogicalId}`);

--- a/create-callout.ts
+++ b/create-callout.ts
@@ -59,18 +59,23 @@ if (validArgs) {
   
     const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
     if (responseOutput) {
-      // Only 1 request was made - verify it succeeded
-      if (responseOutput.results.length == 1 &&
+      if (responseOutput.results.length == 0) {
+        // Success, but the logicalId is not available yet
+        console.log('Create callout succeeded.');
+      } else {
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
           responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
           // Success - logicalId of new callout is available
-          const newDimLogicalId = responseOutput.results[0].logicalId;
-          console.log(`Create callout succeeded and new callout has a logicalId: ${newDimLogicalId}`);
-      } else {
-        console.log(`Create callout failed. Response status code: ${responseOutput.statusCode}.`)
+          const newLogicalId = responseOutput.results[0].logicalId;
+          console.log(`Create callout succeeded and has a logicalId: ${newLogicalId}`);
+        } else {
+          console.log(`Create callout failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       }
     } else {
-      console.log('Create callout failed waiting for modify to finish.');
-      LOG.info('Create callout failed waiting for modify to finish.');
+      console.log('Create callout with leader failed waiting for modify to finish.');
+      LOG.info('Create callout with leader failed waiting for modify to finish.');
     }
   } catch (error) {
     console.error(error);

--- a/create-centerline.ts
+++ b/create-centerline.ts
@@ -34,7 +34,7 @@ if (validArgs) {
     /**
      * Retrieve a drawing view and some of its edges to get information to create the centerline
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
     
     if (viewToUse !== null) {
@@ -95,14 +95,19 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Create centerline with leader succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
             responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new centerline is available
-            const newDimLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Create centerline succeeded and new centerline has a logicalId: ${newDimLogicalId}`);
-        } else {
-          console.log(`Create centerline failed. Response status code: ${responseOutput.statusCode}.`)
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create centerline succeeded and has a logicalId: ${newLogicalId}`);
+          } else {
+            console.log(`Create centerline failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Create centerline failed waiting for modify to finish.');

--- a/create-centerline.ts
+++ b/create-centerline.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData } from './utils/drawingutils.js';
 
 const LOG = mainLog();
@@ -93,8 +93,8 @@ if (validArgs) {
 
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
   
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully created centerline.');
         LOG.info(`Successfully created centerline.`);
       } else {

--- a/create-centerline.ts
+++ b/create-centerline.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData } from './utils/drawingutils.js';
 
 const LOG = mainLog();
@@ -95,8 +95,15 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        console.log('Successfully created centerline.');
-        LOG.info(`Successfully created centerline.`);
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            // Success - logicalId of new centerline is available
+            const newDimLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create centerline succeeded and new centerline has a logicalId: ${newDimLogicalId}`);
+        } else {
+          console.log(`Create centerline failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       } else {
         console.log('Create centerline failed waiting for modify to finish.');
         LOG.info('Create centerline failed waiting for modify to finish.');

--- a/create-centerline.ts
+++ b/create-centerline.ts
@@ -97,7 +97,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new centerline is available
             const newDimLogicalId = responseOutput.results[0].logicalId;
             console.log(`Create centerline succeeded and new centerline has a logicalId: ${newDimLogicalId}`);

--- a/create-diameter-dimension.ts
+++ b/create-diameter-dimension.ts
@@ -119,7 +119,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
             const newDimLogicalId = responseOutput.results[0].logicalId;
             console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);

--- a/create-diameter-dimension.ts
+++ b/create-diameter-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, View2, SnapPointType, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, isArcAxisPerpendicularToViewPlane, convertPointViewToPaper, pointOnCircle } from './utils/drawingutils.js';
 
@@ -115,8 +115,8 @@ if (validArgs) {
 
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`,  requestBody) as BasicNode;
   
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully created dimension.');
         LOG.info(`Successfully created dimension.`);
       } else {

--- a/create-diameter-dimension.ts
+++ b/create-diameter-dimension.ts
@@ -36,7 +36,7 @@ if (validArgs) {
     /**
      * Retrieve a drawing view and some of its edges to get enough information to create the diameter dimension
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
     
     if (viewToUse !== null) {
@@ -117,14 +117,19 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Create dimension succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
             responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
-            const newDimLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
-        } else {
-          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and has a logicalId: ${newLogicalId}`);
+          } else {
+            console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');

--- a/create-geometric-tolerance.ts
+++ b/create-geometric-tolerance.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getRandomLocation } from './utils/drawingutils.js';
 
 const LOG = mainLog();
@@ -54,8 +54,8 @@ if (validArgs) {
 
     const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`,  requestBody) as BasicNode;
   
-    const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-    if (waitSucceeded) {
+    const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+    if (responseOutput) {
       console.log('Successfully created geometric tolerance.');
       LOG.info(`Successfully created geometric tolerance.`);
     } else {

--- a/create-geometric-tolerance.ts
+++ b/create-geometric-tolerance.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getRandomLocation } from './utils/drawingutils.js';
 
 const LOG = mainLog();
@@ -56,14 +56,21 @@ if (validArgs) {
   
     const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
     if (responseOutput) {
-      console.log('Successfully created geometric tolerance.');
-      LOG.info(`Successfully created geometric tolerance.`);
+      // Only 1 request was made - verify it succeeded
+      if (responseOutput.results.length == 1 &&
+          responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+          // Success - logicalId of new geometric tolerance is available
+          const newDimLogicalId = responseOutput.results[0].logicalId;
+          console.log(`Create geometric tolerance succeeded and new gtol has a logicalId: ${newDimLogicalId}`);
+      } else {
+        console.log(`Create geometric tolerance failed. Response status code: ${responseOutput.statusCode}.`)
+      }
     } else {
       console.log('Create geometric tolerance failed waiting for modify to finish.');
       LOG.info('Create geometric tolerance failed waiting for modify to finish.');
     }
   } catch (error) {
     console.error(error);
-    LOG.error('Create geometric tolerance failed', error);
+    LOG.error(`Create geometric tolerance failed: ${error}`);
   }
 }

--- a/create-geometric-tolerance.ts
+++ b/create-geometric-tolerance.ts
@@ -58,7 +58,7 @@ if (validArgs) {
     if (responseOutput) {
       // Only 1 request was made - verify it succeeded
       if (responseOutput.results.length == 1 &&
-          responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+          responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
           // Success - logicalId of new geometric tolerance is available
           const newDimLogicalId = responseOutput.results[0].logicalId;
           console.log(`Create geometric tolerance succeeded and new gtol has a logicalId: ${newDimLogicalId}`);

--- a/create-geometric-tolerance.ts
+++ b/create-geometric-tolerance.ts
@@ -56,14 +56,19 @@ if (validArgs) {
   
     const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
     if (responseOutput) {
-      // Only 1 request was made - verify it succeeded
-      if (responseOutput.results.length == 1 &&
+      if (responseOutput.results.length == 0) {
+        // Success, but the logicalId is not available yet
+        console.log('Create geometric tolerance succeeded.');
+      } else {
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
           responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
           // Success - logicalId of new geometric tolerance is available
-          const newDimLogicalId = responseOutput.results[0].logicalId;
-          console.log(`Create geometric tolerance succeeded and new gtol has a logicalId: ${newDimLogicalId}`);
-      } else {
-        console.log(`Create geometric tolerance failed. Response status code: ${responseOutput.statusCode}.`)
+          const newLogicalId = responseOutput.results[0].logicalId;
+          console.log(`Create geometric tolerance succeeded and has a logicalId: ${newLogicalId}`);
+        } else {
+          console.log(`Create geometric tolerance failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       }
     } else {
       console.log('Create geometric tolerance failed waiting for modify to finish.');

--- a/create-inspection-symbols.ts
+++ b/create-inspection-symbols.ts
@@ -153,7 +153,7 @@ if (validArgs) {
           for (let iResultCount: number = 0; iResultCount < responseOutput.results.length; iResultCount++) {
             let currentResult = responseOutput.results[iResultCount];
             // currentResult.logicalId has the logicalId of each created inspection symbol
-            if (currentResult.status === SingleRequestResultStatus.RequestSucceeded) {
+            if (currentResult.status === SingleRequestResultStatus.RequestSuccess) {
               countSucceeded++;
             } else {
               countFailed++;

--- a/create-inspection-symbols.ts
+++ b/create-inspection-symbols.ts
@@ -32,7 +32,7 @@ if (validArgs) {
     /**
      * Retrieve a drawing view and some of its edges to get enough information to create the inspection symbol
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
   
     if (viewToUse != null) {
@@ -148,24 +148,50 @@ if (validArgs) {
   
         const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
         if (responseOutput) {
-          let countSucceeded = 0;
-          let countFailed = 0;
-          for (let iResultCount: number = 0; iResultCount < responseOutput.results.length; iResultCount++) {
-            let currentResult = responseOutput.results[iResultCount];
-            // currentResult.logicalId has the logicalId of each created inspection symbol
-            if (currentResult.status === SingleRequestResultStatus.RequestSuccess) {
-              countSucceeded++;
+          if (responseOutput.results.length == 0) {
+            // Success, but the logicalId is not available yet
+            console.log('Create geometric tolerance succeeded.');
+          } else {
+            // Only 1 request was made - verify it succeeded
+            if (responseOutput.results.length == 1 &&
+              responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
+              // Success - logicalId of new geometric tolerance is available
+              const newLogicalId = responseOutput.results[0].logicalId;
+              console.log(`Create geometric tolerance succeeded and has a logicalId: ${newLogicalId}`);
             } else {
-              countFailed++;
+              console.log(`Create geometric tolerance failed. Response status code: ${responseOutput.statusCode}.`)
             }
           }
-          console.log(`Successfully created ${countSucceeded} of ${annotationsToRequest.length} inspection symbols.`);
-          if (countFailed > 0) {
-            console.log(`Failed to create ${countFailed} inspection symbols.`);
-          }
-          if (annotationsToRequest.length !== (countSucceeded + countFailed)) {
-            let countTotal = countSucceeded + countFailed;
-            console.log(`Mismatch in number of inspection symbols requested (${annotationsToRequest.length}) and response (${countTotal}).`);
+        } else {
+          console.log('Create geometric tolerance failed waiting for modify to finish.');
+          LOG.info('Create geometric tolerance failed waiting for modify to finish.');
+        }
+
+
+        if (responseOutput) {
+          if (responseOutput.results.length == 0) {
+            // Success, but the counts and logicalIds are not available yet
+            console.log('Create inspection symbols succeeded.');
+          } else {
+            let countSucceeded = 0;
+            let countFailed = 0;
+            for (let iResultCount: number = 0; iResultCount < responseOutput.results.length; iResultCount++) {
+              let currentResult = responseOutput.results[iResultCount];
+              // currentResult.logicalId has the logicalId of each created inspection symbol
+              if (currentResult.status === SingleRequestResultStatus.RequestSuccess) {
+                countSucceeded++;
+              } else {
+                countFailed++;
+              }
+            }
+            console.log(`Successfully created ${countSucceeded} of ${annotationsToRequest.length} inspection symbols.`);
+            if (countFailed > 0) {
+              console.log(`Failed to create ${countFailed} inspection symbols.`);
+            }
+            if (annotationsToRequest.length !== (countSucceeded + countFailed)) {
+              let countTotal = countSucceeded + countFailed;
+              console.log(`Mismatch in number of inspection symbols requested (${annotationsToRequest.length}) and response (${countTotal}).`);
+            }
           }
         } else {
           console.log('Create inspection symbols failed waiting for modify to finish.');

--- a/create-inspection-symbols.ts
+++ b/create-inspection-symbols.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, GetDrawingJsonExportResponse, View2, Annotation, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, GetDrawingJsonExportResponse, View2, Annotation, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, getAnnotationsOfViewAndSheetFromExportData } from './utils/drawingutils.js';
 
@@ -146,8 +146,8 @@ if (validArgs) {
           }]
         }) as BasicNode;
   
-        const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-        if (waitSucceeded) {
+        const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+        if (responseOutput) {
           console.log('Successfully created inspection symbols.');
           LOG.info(`Successfully created inspection symbols.`);
         } else {

--- a/create-line-to-line-angular-dimension.ts
+++ b/create-line-to-line-angular-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint, areParallelEdges } from './utils/drawingutils.js';
 
@@ -139,8 +139,8 @@ if (validArgs) {
 
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
   
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully created dimension.');
         LOG.info(`Successfully created dimension.`);
       } else {

--- a/create-line-to-line-angular-dimension.ts
+++ b/create-line-to-line-angular-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint, areParallelEdges } from './utils/drawingutils.js';
 
@@ -141,8 +141,15 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        console.log('Successfully created dimension.');
-        LOG.info(`Successfully created dimension.`);
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            // Success - logicalId of new dimension is available
+            const newDimLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
+        } else {
+          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');
         LOG.info('Create dimension failed waiting for modify to finish.');

--- a/create-line-to-line-angular-dimension.ts
+++ b/create-line-to-line-angular-dimension.ts
@@ -143,7 +143,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
             const newDimLogicalId = responseOutput.results[0].logicalId;
             console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);

--- a/create-line-to-line-angular-dimension.ts
+++ b/create-line-to-line-angular-dimension.ts
@@ -37,7 +37,7 @@ if (validArgs) {
     /**
      * Retrieve a drawing view and some of its edges to get enough information to create the dimension
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
 
     if (viewToUse !== null) {
@@ -141,14 +141,19 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Create dimension succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
             responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
-            const newDimLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
-        } else {
-          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and has a logicalId: ${newLogicalId}`);
+          } else {
+            console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');

--- a/create-line-to-line-linear-dimension.ts
+++ b/create-line-to-line-linear-dimension.ts
@@ -111,7 +111,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
             const newDimLogicalId = responseOutput.results[0].logicalId;
             console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);

--- a/create-line-to-line-linear-dimension.ts
+++ b/create-line-to-line-linear-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, DrawingObjectType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getRandomLocation } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint, areParallelEdges } from './utils/drawingutils.js';
 
@@ -109,8 +109,15 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        console.log('Successfully created dimension.');
-        LOG.info(`Successfully created dimension.`);
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            // Success - logicalId of new dimension is available
+            const newDimLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
+        } else {
+          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');
         LOG.info('Create dimension failed waiting for modify to finish.');

--- a/create-line-to-line-linear-dimension.ts
+++ b/create-line-to-line-linear-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getRandomLocation } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint, areParallelEdges } from './utils/drawingutils.js';
 
@@ -107,8 +107,8 @@ if (validArgs) {
        */
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
   
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully created dimension.');
         LOG.info(`Successfully created dimension.`);
       } else {

--- a/create-line-to-line-linear-dimension.ts
+++ b/create-line-to-line-linear-dimension.ts
@@ -34,7 +34,7 @@ if (validArgs) {
     /**
      * Retrieve a drawing view and some of its edges to get enough information to create the dimension
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
 
     if (viewToUse !== null) {
@@ -109,14 +109,19 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Create dimension succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
             responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
-            const newDimLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
-        } else {
-          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and has a logicalId: ${newLogicalId}`);
+          } else {
+            console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');

--- a/create-note-with-leader.ts
+++ b/create-note-with-leader.ts
@@ -37,7 +37,7 @@ if (validArgs) {
      * Retrieve a drawing view and some of its edges to get enough information to create the note with leader
      */
 
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
 
     if (viewToUse !== null) {
@@ -105,14 +105,19 @@ if (validArgs) {
     
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Create note with leader succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
             responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new note is available
-            const newNoteLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Create note with leader succeeded and new note has a logicalId: ${newNoteLogicalId}`);
-        } else {
-          console.log(`Create note with leader failed. Response status code: ${responseOutput.statusCode}.`)
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create note with leader succeeded and has a logicalId: ${newLogicalId}`);
+          } else {
+            console.log(`Create note with leader failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Create note with leader failed waiting for modify to finish.');

--- a/create-note-with-leader.ts
+++ b/create-note-with-leader.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, convertPointViewToPaper } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData } from './utils/drawingutils.js';
 
@@ -105,8 +105,15 @@ if (validArgs) {
     
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        console.log('Successfully created note with leader.');
-        LOG.info(`Successfully created note with leader.`);
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            // Success - logicalId of new note is available
+            const newNoteLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create note with leader succeeded and new note has a logicalId: ${newNoteLogicalId}`);
+        } else {
+          console.log(`Create note with leader failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       } else {
         console.log('Create note with leader failed waiting for modify to finish.');
         LOG.info('Create note with leader failed waiting for modify to finish.');

--- a/create-note-with-leader.ts
+++ b/create-note-with-leader.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, View2, SnapPointType, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, convertPointViewToPaper } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData } from './utils/drawingutils.js';
 
@@ -103,8 +103,8 @@ if (validArgs) {
 
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
     
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully created note with leader.');
         LOG.info(`Successfully created note with leader.`);
       } else {

--- a/create-note-with-leader.ts
+++ b/create-note-with-leader.ts
@@ -107,7 +107,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new note is available
             const newNoteLogicalId = responseOutput.results[0].logicalId;
             console.log(`Create note with leader succeeded and new note has a logicalId: ${newNoteLogicalId}`);

--- a/create-note.ts
+++ b/create-note.ts
@@ -55,7 +55,7 @@ if (validArgs) {
     if (responseOutput) {
       // Only 1 request was made - verify it succeeded
       if (responseOutput.results.length == 1 &&
-          responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+          responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
           // Success - logicalId of new note is available
           const newNoteLogicalId = responseOutput.results[0].logicalId;
           console.log(`Create note succeeded and new note has a logicalId: ${newNoteLogicalId}`);

--- a/create-note.ts
+++ b/create-note.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getRandomLocation } from './utils/drawingutils.js';
 
 const LOG = mainLog();
@@ -51,8 +51,8 @@ if (validArgs) {
 
     const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
   
-    const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-    if (waitSucceeded) {
+    const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+    if (responseOutput) {
       console.log('Successfully created note.');
       LOG.info(`Successfully created note.`);
     } else {

--- a/create-note.ts
+++ b/create-note.ts
@@ -53,14 +53,19 @@ if (validArgs) {
   
     const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
     if (responseOutput) {
-      // Only 1 request was made - verify it succeeded
-      if (responseOutput.results.length == 1 &&
+      if (responseOutput.results.length == 0) {
+        // Success, but the logicalId is not available yet
+        console.log('Create note succeeded.');
+      } else {
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
           responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
           // Success - logicalId of new note is available
-          const newNoteLogicalId = responseOutput.results[0].logicalId;
-          console.log(`Create note succeeded and new note has a logicalId: ${newNoteLogicalId}`);
-      } else {
-        console.log(`Create note failed. Response status code: ${responseOutput.statusCode}.`)
+          const newLogicalId = responseOutput.results[0].logicalId;
+          console.log(`Create note succeeded and has a logicalId: ${newLogicalId}`);
+        } else {
+          console.log(`Create note failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       }
     } else {
       console.log('Create note failed waiting for modify to finish.');

--- a/create-note.ts
+++ b/create-note.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getRandomLocation } from './utils/drawingutils.js';
 
 const LOG = mainLog();
@@ -53,8 +53,15 @@ if (validArgs) {
   
     const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
     if (responseOutput) {
-      console.log('Successfully created note.');
-      LOG.info(`Successfully created note.`);
+      // Only 1 request was made - verify it succeeded
+      if (responseOutput.results.length == 1 &&
+          responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+          // Success - logicalId of new note is available
+          const newNoteLogicalId = responseOutput.results[0].logicalId;
+          console.log(`Create note succeeded and new note has a logicalId: ${newNoteLogicalId}`);
+      } else {
+        console.log(`Create note failed. Response status code: ${responseOutput.statusCode}.`)
+      }
     } else {
       console.log('Create note failed waiting for modify to finish.');
       LOG.info('Create note failed waiting for modify to finish.');

--- a/create-point-to-line-linear-dimension.ts
+++ b/create-point-to-line-linear-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint } from './utils/drawingutils.js';
 
@@ -121,8 +121,8 @@ if (validArgs) {
 
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
   
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully created dimension.');
         LOG.info(`Successfully created dimension.`);
       } else {

--- a/create-point-to-line-linear-dimension.ts
+++ b/create-point-to-line-linear-dimension.ts
@@ -125,7 +125,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
             const newDimLogicalId = responseOutput.results[0].logicalId;
             console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);

--- a/create-point-to-line-linear-dimension.ts
+++ b/create-point-to-line-linear-dimension.ts
@@ -36,7 +36,7 @@ if (validArgs) {
     /**
      * Retrieve a drawing view and some of its edges to get enough information to create the dimension
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
   
     if (viewToUse !== null) {
@@ -123,14 +123,19 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Create dimension succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
             responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
-            const newDimLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
-        } else {
-          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and has a logicalId: ${newLogicalId}`);
+          } else {
+            console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');

--- a/create-point-to-line-linear-dimension.ts
+++ b/create-point-to-line-linear-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, DrawingObjectType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint } from './utils/drawingutils.js';
 
@@ -123,8 +123,15 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        console.log('Successfully created dimension.');
-        LOG.info(`Successfully created dimension.`);
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            // Success - logicalId of new dimension is available
+            const newDimLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
+        } else {
+          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');
         LOG.info('Create dimension failed waiting for modify to finish.');

--- a/create-point-to-point-linear-dimension.ts
+++ b/create-point-to-point-linear-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint } from './utils/drawingutils.js';
 
@@ -116,8 +116,15 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        console.log('Successfully created dimension.');
-        LOG.info(`Successfully created dimension.`);
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            // Success - logicalId of new dimension is available
+            const newDimLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
+        } else {
+          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');
         LOG.info('Create dimension failed waiting for modify to finish.');

--- a/create-point-to-point-linear-dimension.ts
+++ b/create-point-to-point-linear-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint } from './utils/drawingutils.js';
 
@@ -114,8 +114,8 @@ if (validArgs) {
        */
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
   
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully created dimension.');
         LOG.info(`Successfully created dimension.`);
       } else {

--- a/create-point-to-point-linear-dimension.ts
+++ b/create-point-to-point-linear-dimension.ts
@@ -36,7 +36,7 @@ if (validArgs) {
     /**
      * Retrieve a drawing view and some of its edges to get enough information to create the dimension
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
     
     if (viewToUse !== null) {
@@ -116,14 +116,19 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Create dimension succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
             responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
-            const newDimLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
-        } else {
-          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and has a logicalId: ${newLogicalId}`);
+          } else {
+            console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');

--- a/create-point-to-point-linear-dimension.ts
+++ b/create-point-to-point-linear-dimension.ts
@@ -118,7 +118,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
             const newDimLogicalId = responseOutput.results[0].logicalId;
             console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);

--- a/create-radial-dimension.ts
+++ b/create-radial-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, SnapPointType, View2 } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, SnapPointType, View2, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, isArcAxisPerpendicularToViewPlane, convertPointViewToPaper, midPointOfArc } from './utils/drawingutils.js';
 
@@ -110,8 +110,8 @@ if (validArgs) {
        */
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
   
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully created dimension.');
         LOG.info(`Successfully created dimension.`);
       } else {

--- a/create-radial-dimension.ts
+++ b/create-radial-dimension.ts
@@ -34,7 +34,7 @@ if (validArgs) {
     /**
      * Retrieve a drawing view and some of its edges to get enough information to create the radial dimension
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
   
     if (viewToUse !== null) {
@@ -112,14 +112,19 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Create dimension succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
             responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
-            const newDimLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
-        } else {
-          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and has a logicalId: ${newLogicalId}`);
+          } else {
+            console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');

--- a/create-radial-dimension.ts
+++ b/create-radial-dimension.ts
@@ -114,7 +114,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
             const newDimLogicalId = responseOutput.results[0].logicalId;
             console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);

--- a/create-radial-dimension.ts
+++ b/create-radial-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, SnapPointType, View2, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, Edge, GetDrawingJsonExportResponse, GetViewJsonGeometryResponse, SnapPointType, View2, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, isArcAxisPerpendicularToViewPlane, convertPointViewToPaper, midPointOfArc } from './utils/drawingutils.js';
 
@@ -112,8 +112,15 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        console.log('Successfully created dimension.');
-        LOG.info(`Successfully created dimension.`);
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            // Success - logicalId of new dimension is available
+            const newDimLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
+        } else {
+          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');
         LOG.info('Create dimension failed waiting for modify to finish.');

--- a/create-table.ts
+++ b/create-table.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getRandomLocation } from './utils/drawingutils.js';
 
 const LOG = mainLog();
@@ -297,8 +297,8 @@ if (validArgs) {
      */
     const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
   
-    const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-    if (waitSucceeded) {
+    const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+    if (responseOutput) {
       console.log('Successfully created table.');
       LOG.info(`Successfully created table.`);
     } else {

--- a/create-table.ts
+++ b/create-table.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getRandomLocation } from './utils/drawingutils.js';
 
 const LOG = mainLog();
@@ -299,8 +299,15 @@ if (validArgs) {
   
     const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
     if (responseOutput) {
-      console.log('Successfully created table.');
-      LOG.info(`Successfully created table.`);
+      // Only 1 request was made - verify it succeeded
+      if (responseOutput.results.length == 1 &&
+          responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+          // Success - logicalId of new table is available
+          const newTableLogicalId = responseOutput.results[0].logicalId;
+          console.log(`Create table succeeded and new table has a logicalId: ${newTableLogicalId}`);
+      } else {
+        console.log(`Create table failed. Response status code: ${responseOutput.statusCode}.`)
+      }
     } else {
       console.log('Create table failed waiting for modify to finish.');
       LOG.info('Create table failed waiting for modify to finish.');

--- a/create-table.ts
+++ b/create-table.ts
@@ -301,7 +301,7 @@ if (validArgs) {
     if (responseOutput) {
       // Only 1 request was made - verify it succeeded
       if (responseOutput.results.length == 1 &&
-          responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+          responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
           // Success - logicalId of new table is available
           const newTableLogicalId = responseOutput.results[0].logicalId;
           console.log(`Create table succeeded and new table has a logicalId: ${newTableLogicalId}`);

--- a/create-table.ts
+++ b/create-table.ts
@@ -299,14 +299,19 @@ if (validArgs) {
   
     const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
     if (responseOutput) {
-      // Only 1 request was made - verify it succeeded
-      if (responseOutput.results.length == 1 &&
+      if (responseOutput.results.length == 0) {
+        // Success, but the logicalId is not available yet
+        console.log('Create table succeeded.');
+      } else {
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
           responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
           // Success - logicalId of new table is available
-          const newTableLogicalId = responseOutput.results[0].logicalId;
-          console.log(`Create table succeeded and new table has a logicalId: ${newTableLogicalId}`);
-      } else {
-        console.log(`Create table failed. Response status code: ${responseOutput.statusCode}.`)
+          const newLogicalId = responseOutput.results[0].logicalId;
+          console.log(`Create table succeeded and has a logicalId: ${newLogicalId}`);
+        } else {
+          console.log(`Create table failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       }
     } else {
       console.log('Create table failed waiting for modify to finish.');

--- a/create-three-point-angular-dimension.ts
+++ b/create-three-point-angular-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, ModifyStatusResponseOutput, SingleRequestResultStatus } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint, areCoincidentPoints } from './utils/drawingutils.js';
 
@@ -141,8 +141,15 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        console.log('Successfully created dimension.');
-        LOG.info(`Successfully created dimension.`);
+        // Only 1 request was made - verify it succeeded
+        if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            // Success - logicalId of new dimension is available
+            const newDimLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
+        } else {
+          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+        }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');
         LOG.info('Create dimension failed waiting for modify to finish.');

--- a/create-three-point-angular-dimension.ts
+++ b/create-three-point-angular-dimension.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, View2, SnapPointType, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getRandomViewOnActiveSheetFromExportData, convertPointViewToPaper, getMidPoint, areCoincidentPoints } from './utils/drawingutils.js';
 
@@ -139,8 +139,8 @@ if (validArgs) {
        */
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
   
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully created dimension.');
         LOG.info(`Successfully created dimension.`);
       } else {

--- a/create-three-point-angular-dimension.ts
+++ b/create-three-point-angular-dimension.ts
@@ -143,7 +143,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
             const newDimLogicalId = responseOutput.results[0].logicalId;
             console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);

--- a/create-three-point-angular-dimension.ts
+++ b/create-three-point-angular-dimension.ts
@@ -37,7 +37,7 @@ if (validArgs) {
     /**
      * Retrieve a drawing view and some of its edges to get enough information to create the dimension
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewToUse = getRandomViewOnActiveSheetFromExportData(drawingJsonExport);
 
     if (viewToUse !== null) {
@@ -141,14 +141,19 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Create dimension succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
             responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of new dimension is available
-            const newDimLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Create dimension succeeded and new dimension has a logicalId: ${newDimLogicalId}`);
-        } else {
-          console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Create dimension succeeded and has a logicalId: ${newLogicalId}`);
+          } else {
+            console.log(`Create dimension failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Create dimension failed waiting for modify to finish.');

--- a/detect-if-single-drawing-needs-update.ts
+++ b/detect-if-single-drawing-needs-update.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { usage, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getDrawingNeedUpdate } from './utils/drawingutils.js';
+import { usage, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getIfDrawingNeedsUpdate } from './utils/drawingutils.js';
 
 const LOG = mainLog();
 
@@ -14,14 +14,14 @@ try {
   validateBaseURLs(apiClient.getBaseURL(), drawingScriptArgs.baseURL);
 } catch (error) {
   validArgs = false;
-  usage('detect-update-needed');
+  usage('detect-if-single-drawing-needs-update');
 }
 
 if (validArgs) {
   try {
     LOG.info(`documentId=${drawingScriptArgs.documentId}, workspaceId=${drawingScriptArgs.workspaceId}, elementId=${drawingScriptArgs.elementId}`);
   
-    const drawingNeedsUpdate: boolean = await getDrawingNeedUpdate(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId)
+    const drawingNeedsUpdate: boolean = await getIfDrawingNeedsUpdate(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId)
 
     if (drawingNeedsUpdate) {
       console.log('Drawing needs an update!');
@@ -30,6 +30,6 @@ if (validArgs) {
     }
   } catch (error) {
     console.error(error);
-    LOG.error('Detecting if drawing needs an updated failed', error);
+    LOG.error('Detecting if a drawing needs an update failed', error);
   }
 }

--- a/detect-if-workspace-contains-drawings-needing-update.ts
+++ b/detect-if-workspace-contains-drawings-needing-update.ts
@@ -1,0 +1,36 @@
+import { mainLog } from './utils/logger.js';
+import { ApiClient } from './utils/apiclient.js';
+import { usage, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getWorkspaceDrawingsThatNeedUpdate } from './utils/drawingutils.js';
+
+const LOG = mainLog();
+
+let drawingScriptArgs: DrawingScriptArgs = null;
+let validArgs: boolean = true;
+let apiClient: ApiClient = null;
+
+try {
+  // Note that we do not use the elementId in this script, but chose to use the "drawingUri" argument anyways, for consistency
+  drawingScriptArgs = parseDrawingScriptArgs();
+  apiClient = await ApiClient.createApiClient(drawingScriptArgs.stackToUse);
+  validateBaseURLs(apiClient.getBaseURL(), drawingScriptArgs.baseURL);
+} catch (error) {
+  validArgs = false;
+  usage('detect-if-workspace-contains-drawings-needing-update');
+}
+
+if (validArgs) {
+  try {
+    LOG.info(`documentId=${drawingScriptArgs.documentId}, workspaceId=${drawingScriptArgs.workspaceId}, elementId=${drawingScriptArgs.elementId}`);
+  
+    const drawingsThatNeedUpdate: string[] = await getWorkspaceDrawingsThatNeedUpdate(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId)
+
+    if (drawingsThatNeedUpdate && drawingsThatNeedUpdate.length > 0) {
+      console.log(`Workspace contains ${drawingsThatNeedUpdate.length} drawing(s) that need an update!`);
+    } else {
+      console.log('Workspace does NOT contain any drawings that need an update.');
+    }
+  } catch (error) {
+    console.error(error);
+    LOG.error('Detecting if a workspace contains drawings that need an update failed', error);
+  }
+}

--- a/detect-update-needed.ts
+++ b/detect-update-needed.ts
@@ -1,0 +1,35 @@
+import { mainLog } from './utils/logger.js';
+import { ApiClient } from './utils/apiclient.js';
+import { usage, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs, getDrawingNeedUpdate } from './utils/drawingutils.js';
+
+const LOG = mainLog();
+
+let drawingScriptArgs: DrawingScriptArgs = null;
+let validArgs: boolean = true;
+let apiClient: ApiClient = null;
+
+try {
+  drawingScriptArgs = parseDrawingScriptArgs();
+  apiClient = await ApiClient.createApiClient(drawingScriptArgs.stackToUse);
+  validateBaseURLs(apiClient.getBaseURL(), drawingScriptArgs.baseURL);
+} catch (error) {
+  validArgs = false;
+  usage('detect-update-needed');
+}
+
+if (validArgs) {
+  try {
+    LOG.info(`documentId=${drawingScriptArgs.documentId}, workspaceId=${drawingScriptArgs.workspaceId}, elementId=${drawingScriptArgs.elementId}`);
+  
+    const drawingNeedsUpdate: boolean = await getDrawingNeedUpdate(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId)
+
+    if (drawingNeedsUpdate) {
+      console.log('Drawing needs an update!');
+    } else {
+      console.log('Drawing does NOT need an update.');
+    }
+  } catch (error) {
+    console.error(error);
+    LOG.error('Detecting if drawing needs an updated failed', error);
+  }
+}

--- a/edit-dimension-attachments.ts
+++ b/edit-dimension-attachments.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, SnapPointType, Annotation } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, Edge, GetViewJsonGeometryResponse, GetDrawingJsonExportResponse, SnapPointType, Annotation, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getAllDrawingAnnotationsInViewsFromExportData } from './utils/drawingutils.js';
 
@@ -110,8 +110,8 @@ if (validArgs) {
        */
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
     
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully edited dimensions.');
         LOG.info('Successfully edited dimensions.');
       } else {

--- a/edit-dimension-attachments.ts
+++ b/edit-dimension-attachments.ts
@@ -33,7 +33,7 @@ if (validArgs) {
     /**
      * Retrieve annotations in the drawing
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewAnnotations = getAllDrawingAnnotationsInViewsFromExportData(drawingJsonExport);
 
     /**
@@ -112,17 +112,19 @@ if (validArgs) {
     
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        // Only 1 request was made - verify it succeeded
-        if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
-            // Success - logicalId of edited dimension is available
-            const editedDimLogicalId = responseOutput.results[0].logicalId;
-            console.log(`Edit dimension succeeded and edited dimension has a logicalId: ${editedDimLogicalId}`);
-            if (editedDimLogicalId !== dimensionToEdit.pointToPointDimension.logicalId) {
-              console.log(`ERROR - requested dimension logicalId is ${dimensionToEdit.pointToPointDimension.logicalId} but result logicalId is ${editedDimLogicalId}.`);
-            }
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Edit dimension succeeded.');
         } else {
-          console.log(`Edit dimension failed. Response status code: ${responseOutput.statusCode}.`)
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
+            // Success - logicalId of new dimension is available
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Edit dimension succeeded and has a logicalId: ${newLogicalId}`);
+          } else {
+            console.log(`Edit dimension failed. Response status code: ${responseOutput.statusCode}.`)
+          }
         }
       } else {
         console.log('Edit dimension failed waiting for modify to finish.');

--- a/edit-dimension-attachments.ts
+++ b/edit-dimension-attachments.ts
@@ -114,7 +114,7 @@ if (validArgs) {
       if (responseOutput) {
         // Only 1 request was made - verify it succeeded
         if (responseOutput.results.length == 1 &&
-            responseOutput.results[0].status === SingleRequestResultStatus.RequestSucceeded) {
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
             // Success - logicalId of edited dimension is available
             const editedDimLogicalId = responseOutput.results[0].logicalId;
             console.log(`Edit dimension succeeded and edited dimension has a logicalId: ${editedDimLogicalId}`);

--- a/edit-dimension-text-positions.ts
+++ b/edit-dimension-text-positions.ts
@@ -96,7 +96,7 @@ if (validArgs) {
         let countFailed = 0;
         for (let iResultCount: number = 0; iResultCount < responseOutput.results.length; iResultCount++) {
           let currentResult = responseOutput.results[iResultCount];
-          if (currentResult.status === SingleRequestResultStatus.RequestSucceeded) {
+          if (currentResult.status === SingleRequestResultStatus.RequestSuccess) {
             countSucceeded++;
           } else {
             countFailed++;

--- a/edit-dimension-text-positions.ts
+++ b/edit-dimension-text-positions.ts
@@ -82,6 +82,9 @@ if (validArgs) {
         } ]
       }
 
+      const requestBodyAsString: string = JSON.stringify(requestBody);
+      console.log(requestBodyAsString);
+
       /**
        * Modify the drawing to edit the dimensions
        */
@@ -100,8 +103,12 @@ if (validArgs) {
           }
         }
         console.log(`Successfully edited ${countSucceeded} of ${editAnnotations.length} dimensions.`);
+        if (countFailed > 0) {
+          console.log(`Failed to edit ${countFailed} dimension text positions.`);
+        }
         if (editAnnotations.length !== (countSucceeded + countFailed)) {
-          console.log('Mismatch in number of dimension edits requested and response');
+          let countTotal = countSucceeded + countFailed;
+          console.log(`Mismatch in number of dimension edits requested (${editAnnotations.length}) and response (${countTotal}).`);
         }
       } else {
         console.log('Edit dimensions failed waiting for modify to finish.');

--- a/edit-dimension-text-positions.ts
+++ b/edit-dimension-text-positions.ts
@@ -28,7 +28,7 @@ if (validArgs) {
     /**
      * Retrieve annotations in the drawing
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     viewAnnotations = getAllDrawingAnnotationsInViewsFromExportData(drawingJsonExport);
 
     /**
@@ -92,23 +92,48 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        let countSucceeded = 0;
-        let countFailed = 0;
-        for (let iResultCount: number = 0; iResultCount < responseOutput.results.length; iResultCount++) {
-          let currentResult = responseOutput.results[iResultCount];
-          if (currentResult.status === SingleRequestResultStatus.RequestSuccess) {
-            countSucceeded++;
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Edit dimension succeeded.');
+        } else {
+          // Only 1 request was made - verify it succeeded
+          if (responseOutput.results.length == 1 &&
+            responseOutput.results[0].status === SingleRequestResultStatus.RequestSuccess) {
+            // Success - logicalId of new dimension is available
+            const newLogicalId = responseOutput.results[0].logicalId;
+            console.log(`Edit dimension succeeded and has a logicalId: ${newLogicalId}`);
           } else {
-            countFailed++;
+            console.log(`Edit dimension failed. Response status code: ${responseOutput.statusCode}.`)
           }
         }
-        console.log(`Successfully edited ${countSucceeded} of ${editAnnotations.length} dimensions.`);
-        if (countFailed > 0) {
-          console.log(`Failed to edit ${countFailed} dimension text positions.`);
-        }
-        if (editAnnotations.length !== (countSucceeded + countFailed)) {
-          let countTotal = countSucceeded + countFailed;
-          console.log(`Mismatch in number of dimension edits requested (${editAnnotations.length}) and response (${countTotal}).`);
+      } else {
+        console.log('Edit dimension failed waiting for modify to finish.');
+        LOG.info('Edit dimension failed waiting for modify to finish.');
+      }
+
+      if (responseOutput) {
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Edit dimension succeeded.');
+        } else {
+          let countSucceeded = 0;
+          let countFailed = 0;
+          for (let iResultCount: number = 0; iResultCount < responseOutput.results.length; iResultCount++) {
+            let currentResult = responseOutput.results[iResultCount];
+            if (currentResult.status === SingleRequestResultStatus.RequestSuccess) {
+              countSucceeded++;
+            } else {
+              countFailed++;
+            }
+          }
+          console.log(`Successfully edited ${countSucceeded} of ${editAnnotations.length} dimensions.`);
+          if (countFailed > 0) {
+            console.log(`Failed to edit ${countFailed} dimension text positions.`);
+          }
+          if (editAnnotations.length !== (countSucceeded + countFailed)) {
+            let countTotal = countSucceeded + countFailed;
+            console.log(`Mismatch in number of dimension edits requested (${editAnnotations.length}) and response (${countTotal}).`);
+          }
         }
       } else {
         console.log('Edit dimensions failed waiting for modify to finish.');

--- a/edit-notes.ts
+++ b/edit-notes.ts
@@ -1,6 +1,6 @@
 import { mainLog } from './utils/logger.js';
 import { ApiClient } from './utils/apiclient.js';
-import { BasicNode, DrawingObjectType, Note, GetDrawingJsonExportResponse, Annotation } from './utils/onshapetypes.js';
+import { BasicNode, DrawingObjectType, Note, GetDrawingJsonExportResponse, Annotation, ModifyStatusResponseOutput } from './utils/onshapetypes.js';
 import { usage, waitForModifyToFinish, DrawingScriptArgs, parseDrawingScriptArgs, validateBaseURLs } from './utils/drawingutils.js';
 import { getDrawingJsonExport, getAllDrawingAnnotationsInViewsFromExportData } from './utils/drawingutils.js';
 
@@ -93,8 +93,8 @@ if (validArgs) {
        */
       const modifyRequest = await apiClient.post(`api/v6/drawings/d/${drawingScriptArgs.documentId}/w/${drawingScriptArgs.workspaceId}/e/${drawingScriptArgs.elementId}/modify`, requestBody) as BasicNode;
   
-      const waitSucceeded: boolean = await waitForModifyToFinish(apiClient, modifyRequest.id);
-      if (waitSucceeded) {
+      const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
+      if (responseOutput) {
         console.log('Successfully edited notes.');
         LOG.info(`Successfully edited notes.`);
       } else {

--- a/edit-notes.ts
+++ b/edit-notes.ts
@@ -99,7 +99,7 @@ if (validArgs) {
         let countFailed = 0;
         for (let iResultCount: number = 0; iResultCount < responseOutput.results.length; iResultCount++) {
           let currentResult = responseOutput.results[iResultCount];
-          if (currentResult.status === SingleRequestResultStatus.RequestSucceeded) {
+          if (currentResult.status === SingleRequestResultStatus.RequestSuccess) {
             countSucceeded++;
           } else {
             countFailed++;

--- a/edit-notes.ts
+++ b/edit-notes.ts
@@ -27,7 +27,7 @@ if (validArgs) {
      * Retrieve annotations in the drawing that are associated with views (to avoid annotations in borders, titleblock, etc.).
      * NOTE - THIS MEANS NOTES THAT ARE NOT ASSOCIATED WITH A VIEW (e.g. do not have a leader attached to a view edge) WILL NOT BE EDITED.
      */
-    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
+    let drawingJsonExport: GetDrawingJsonExportResponse = await getDrawingJsonExport(apiClient, drawingScriptArgs.documentId, 'w', drawingScriptArgs.workspaceId, drawingScriptArgs.elementId) as GetDrawingJsonExportResponse;
     let viewAnnotations: Annotation[] = getAllDrawingAnnotationsInViewsFromExportData(drawingJsonExport);
 
     /**
@@ -95,23 +95,28 @@ if (validArgs) {
   
       const responseOutput: ModifyStatusResponseOutput = await waitForModifyToFinish(apiClient, modifyRequest.id);
       if (responseOutput) {
-        let countSucceeded = 0;
-        let countFailed = 0;
-        for (let iResultCount: number = 0; iResultCount < responseOutput.results.length; iResultCount++) {
-          let currentResult = responseOutput.results[iResultCount];
-          if (currentResult.status === SingleRequestResultStatus.RequestSuccess) {
-            countSucceeded++;
-          } else {
-            countFailed++;
+        if (responseOutput.results.length == 0) {
+          // Success, but the logicalId is not available yet
+          console.log('Edit notes succeeded.');
+        } else {
+          let countSucceeded = 0;
+          let countFailed = 0;
+          for (let iResultCount: number = 0; iResultCount < responseOutput.results.length; iResultCount++) {
+            let currentResult = responseOutput.results[iResultCount];
+            if (currentResult.status === SingleRequestResultStatus.RequestSuccess) {
+              countSucceeded++;
+            } else {
+              countFailed++;
+            }
           }
-        }
-        console.log(`Successfully edited ${countSucceeded} of ${editAnnotations.length} notes.`);
-        if (countFailed > 0) {
-          console.log(`Failed to edit ${countFailed} notes.`);
-        }
-        if (editAnnotations.length !== (countSucceeded + countFailed)) {
-          let countTotal = countSucceeded + countFailed;
-          console.log(`Mismatch in number of note edits requested (${editAnnotations.length}) and response (${countTotal}).`);
+          console.log(`Successfully edited ${countSucceeded} of ${editAnnotations.length} notes.`);
+          if (countFailed > 0) {
+            console.log(`Failed to edit ${countFailed} notes.`);
+          }
+          if (editAnnotations.length !== (countSucceeded + countFailed)) {
+            let countTotal = countSucceeded + countFailed;
+            console.log(`Mismatch in number of note edits requested (${editAnnotations.length}) and response (${countTotal}).`);
+          }
         }
       } else {
         console.log('Edit notes failed waiting for modify to finish.');

--- a/find-errors-in-drawing.ts
+++ b/find-errors-in-drawing.ts
@@ -154,6 +154,12 @@ if (validArgs) {
             friendlyType = "Note";
             break;
           }
+          case DrawingObjectType.INSPECTION_SYMBOL: {
+            isDangling = anAnnotation.inspectionSymbol.isDangling ?? false;
+            logicalId = anAnnotation.inspectionSymbol.logicalId ?? '';
+            friendlyType = "Inspection symbol";
+            break;
+          }
           case DrawingObjectType.TABLE:
           default:
             // No isDangling field yet on these types of annotations

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "create-radial-dimension": "node .compiledjs/create-radial-dimension.js",
     "create-table": "node .compiledjs/create-table.js",
     "create-three-point-angular-dimension": "node .compiledjs/create-three-point-angular-dimension.js",
+    "detect-if-single-drawing-needs-update": "node .compiledjs/detect-if-single-drawing-needs-update.js",
+    "detect-if-workspace-contains-drawings-needing-update": "node .compiledjs/detect-if-workspace-contains-drawings-needing-update.js",
     "edit-notes": "node .compiledjs/edit-notes.js",
     "edit-dimension-attachments": "node .compiledjs/edit-dimension-attachments.js",
     "edit-dimension-text-positions": "node .compiledjs/edit-dimension-text-positions.js",

--- a/utils/apiclient.ts
+++ b/utils/apiclient.ts
@@ -7,6 +7,7 @@ import { IUniResponse, IUniRest } from 'unirest';
 import { mainLog } from './logger.js';
 import { ArgumentParser } from './argumentparser.js';
 import { CompanyInfo, ListResponse } from './onshapetypes.js';
+import { getLogName } from './fileutils.js';
 
 const LOG = mainLog();
 
@@ -232,12 +233,24 @@ export class ApiClient {
     } else if ('DELETE' === method) {
       lunitest = lunitest.delete(fullUri);
     }
+
     acceptHeader = acceptHeader || 'application/vnd.onshape.v2+json;charset=UTF-8;qs=0.2';
+    const scriptName = getLogName();
     lunitest.header('Accept', acceptHeader);
+    lunitest.header('User-Agent', `onshape-ts-client-1.1.0/${scriptName}`);
     lunitest.header('Content-Type', contentType);
     lunitest.header('On-Nonce', onNonce);
     lunitest.header('Date', authDate);
     lunitest.header('Authorization', asign);
+
+    /**
+     * Generate unique request id per script so it is easily searchable in kibana
+     *
+     * requestId:osts-revisionexport* AND response:* AND role:web_load_balancer
+     * can be used to search in kibana.
+     */
+    const requestId = randomstring.generate({ length: 24, charset: 'hex' });
+    lunitest.header('X-Request-Id', `osts-${scriptName}-${this.companyId}-${requestId}`);
     return lunitest;
   }
 

--- a/utils/drawingutils.ts
+++ b/utils/drawingutils.ts
@@ -268,9 +268,9 @@ export async function waitForModifyToFinish(apiClient: ApiClient, idModifyReques
   }
 
   if (succeeded && jobStatus.requestState !== 'ACTIVE') {
-
     if (jobStatus.output) {
       console.log(`modify status response output is: ${jobStatus.output}`);
+      // Parses the output string into an object containing the modify results
       jobOutput = JSON.parse(jobStatus.output);
     }
   }

--- a/utils/drawingutils.ts
+++ b/utils/drawingutils.ts
@@ -180,8 +180,8 @@ export async function waitForModifyToFinish(apiClient: ApiClient, idModifyReques
 
   if (succeeded && jobStatus.requestState !== 'ACTIVE') {
     if (jobStatus.output) {
-      jobOutput = JSON.parse(jobStatus.output);
       console.log(`modify status response output is: ${jobStatus.output}`);
+      jobOutput = JSON.parse(jobStatus.output);
     }
   }
 

--- a/utils/onshapetypes.ts
+++ b/utils/onshapetypes.ts
@@ -497,11 +497,25 @@ export interface RadialDimension {
   unit: DimensionUnit;
 }
 
+export interface InspectionSymbol {
+  borderShape: string;
+  borderSize: number;
+  isDangling?: boolean;
+  itemParsing: string;
+  logicalId: string;
+  number: number;
+  parentAnnotation: string;
+  parentLineIndex: number;
+  position: UnassociatedPoint;
+  textHeight: number;
+}
+
 export interface Annotation {
   type: string;
   callout?: Callout;
   diametricDimension?: DiameterDimension;
   geometricTolerance?: GeometricTolerance;
+  inspectionSymbol?: InspectionSymbol;
   lineToLineAngularDimension?: LineToLineAngularDimension;
   lineToLineDimension?: LineToLineLinearDimension;
   note?: Note;
@@ -551,7 +565,7 @@ export class SingleRequestType {
 // The response to a single JSON request (create, edit, delete) of (annotation, view, sheet, etc.)
 export interface SingleRequestResponse {
   status: SingleRequestResultStatus;
-  logicalId: string;
+  logicalId?: string;         // Field exists and has a value if status is "OK"
   errorDescription?: string;  // Field exists and has a value if status is "Failed"
 }
 

--- a/utils/onshapetypes.ts
+++ b/utils/onshapetypes.ts
@@ -161,6 +161,10 @@ export interface ReleasePackageItemUpdate {
 export class DrawingObjectType {
   static CALLOUT = 'Onshape::Callout';
   static CENTERLINE_POINT_TO_POINT = 'Onshape::Centerline::PointToPoint';
+  static CENTERLINE_LINE_TO_LINE = 'Onshape::Centerline::LineToLine';
+  static CENTERLINE_TWO_POINT_CIRCULAR = 'Onshape::Centerline::TwoPointCircleCenterline';
+  static CENTERLINE_THREE_POINT_CIRCULAR = 'Onshape::Centerline::ThreePointCircleCenterline';
+  static CHAMFER_NOTE = 'Onshape::Dimension::ChamferNote';
   static DIMENSION_DIAMETER = 'Onshape::Dimension::Diametric';
   static DIMENSION_LINE_TO_LINE_ANGULAR = 'Onshape::Dimension::LineToLineAngular';
   static DIMENSION_LINE_TO_LINE_LINEAR = 'Onshape::Dimension::LineToLine';
@@ -400,11 +404,50 @@ export interface Note {
   textHeight?: number;
 }
 
+export interface ChamferNote {
+  displayedValue: string;
+  edge1End: AssociatedPoint;
+  edge1Start: AssociatedPoint;
+  edge2End: AssociatedPoint;
+  edge2Start: AssociatedPoint;
+  formatting?: DimensionFormatting;
+  isDangling?: boolean;
+  logicalId: string;
+  measurementAngle: number;
+  measurementLength: number;
+  secondUnit: DimensionUnit;
+  textOverride: string;
+  textPosition: UnassociatedPoint;
+  unit: DimensionUnit;
+}
+
 export interface PointToPointCenterline {
   isDangling: boolean;
   logicalId: string;
   point1: AssociatedPoint;
   point2: AssociatedPoint;
+}
+
+export interface LineToLineCenterline {
+  isDangling?: boolean;
+  logicalId: string;
+  edge1: AssociatedEdge;
+  edge2: AssociatedEdge;
+}
+
+export interface TwoPointCircleCenterline {
+  isDangling?: boolean;
+  logicalId: string;
+  centerPoint: AssociatedPoint;
+  defPoint: AssociatedPoint;
+}
+
+export interface ThreePointCircleCenterline {
+  isDangling?: boolean;
+  logicalId: string;
+  point1: AssociatedPoint;
+  point2: AssociatedPoint;
+  point3: AssociatedPoint;
 }
 
 export interface PointToPointLinearDimension {
@@ -513,10 +556,12 @@ export interface InspectionSymbol {
 export interface Annotation {
   type: string;
   callout?: Callout;
+  chamferNote?: ChamferNote;
   diametricDimension?: DiameterDimension;
   geometricTolerance?: GeometricTolerance;
   inspectionSymbol?: InspectionSymbol;
   lineToLineAngularDimension?: LineToLineAngularDimension;
+  lineToLineCenterline?: LineToLineCenterline;
   lineToLineDimension?: LineToLineLinearDimension;
   note?: Note;
   pointToLineDimension?: PointToLineLinearDimension;
@@ -524,6 +569,8 @@ export interface Annotation {
   pointToPointDimension?: PointToPointLinearDimension;
   radialDimension?: RadialDimension;
   threePointAngularDimension?: ThreePointAngularDimension;
+  threePointCircleCenterline?: ThreePointCircleCenterline;
+  twoPointCircleCenterline?: TwoPointCircleCenterline;
 }
 
 export interface Sheet {
@@ -568,7 +615,6 @@ export interface SingleRequestResponse {
   logicalId?: string;         // Field exists and has a value if status is "OK"
   errorDescription?: string;  // Field exists and has a value if status is "Failed"
 }
-
 export interface ModifyStatusResponseOutput {
   status: OverallRequestResultStatus;
   statusCode: number;

--- a/utils/onshapetypes.ts
+++ b/utils/onshapetypes.ts
@@ -583,6 +583,7 @@ export interface DrawingReference {
 }
 
 export interface ResolveReferencesResponse {
+  unresolvedReferences: DrawingReference[];
   resolvedReferences: DrawingReference[];
 }
 

--- a/utils/onshapetypes.ts
+++ b/utils/onshapetypes.ts
@@ -531,7 +531,7 @@ export interface GetDrawingJsonExportResponse {
   sheets: Sheet[];
 }
 
-export class SingleRequestResponseStatus {
+export class SingleRequestResultStatus {
   static RequestSucceeded = 'OK';       // Succeeded
   static RequestFailed = 'Failed';      // Failed
 }
@@ -544,14 +544,14 @@ export class SingleRequestType {
  
 // The response to a single JSON request (create, edit, delete) of (annotation, view, sheet, etc.)
 export interface SingleRequestResponse {
-  status: SingleRequestResponseStatus;
-  requestType: SingleRequestType;
+  status: SingleRequestResultStatus;
   logicalId: string;
-  objectType: DrawingObjectType
 }
 
-export interface ModifyStatusResponse {
-  overallStatus: boolean;
+export interface ModifyStatusResponseOutput {
+  status: SingleRequestResultStatus;
+  statusCode: number;
   changeId: string;
-  requests: SingleRequestResponse[];
+  results: SingleRequestResponse[];
 }
+

--- a/utils/onshapetypes.ts
+++ b/utils/onshapetypes.ts
@@ -531,27 +531,58 @@ export interface GetDrawingJsonExportResponse {
   sheets: Sheet[];
 }
 
+export class OverallRequestResultStatus {
+  static OverallRequestSuccess = 'OK';                         // All requests succeeded
+  static OverallRequestPartialSuccessed = 'Partial_success';   // Some requests succeeded, some failed
+  static OverallRequestFailed = 'Failed';                      // All requests failed
+}
+
 export class SingleRequestResultStatus {
-  static RequestSucceeded = 'OK';       // Succeeded
-  static RequestFailed = 'Failed';      // Failed
+  static RequestSuccess = 'OK';       // Success
+  static RequestFailed = 'Failed';    // Failed
 }
 
 export class SingleRequestType {
-  static RequestTypeCreate = "Create";
-  static RequestTypeEdit = "Edit";
-  static RequestTypeDelete = "Delete";
+  static RequestTypeCreate = 'Create';
+  static RequestTypeEdit = 'Edit';
+  static RequestTypeDelete = 'Delete';
 }
  
 // The response to a single JSON request (create, edit, delete) of (annotation, view, sheet, etc.)
 export interface SingleRequestResponse {
   status: SingleRequestResultStatus;
   logicalId: string;
+  errorDescription?: string;  // Field exists and has a value if status is "Failed"
 }
 
 export interface ModifyStatusResponseOutput {
-  status: SingleRequestResultStatus;
+  status: OverallRequestResultStatus;
   statusCode: number;
+  errorDescription?: string;  // Field exists and has a value if overall status is "Partial_success" or "Failed"
   changeId: string;
   results: SingleRequestResponse[];
+}
+
+export interface DrawingReference {
+  targetElementMicroversionId: string;
+  latestElementMicroversionId: string;
+  resolvedElementMicroversionId: string;
+  sourceElementId: string;
+  idTagIsValid: boolean;
+  targetDocumentId: string;
+  targetVersionId: string;
+  resolvedDocumentMicroversionId: string;
+  targetElementId: string;
+  targetConfiguration: string;
+  changeId: string;
+  idTag: string;
+  referenceId: string;
+  isLocked: boolean;
+  targetDocumentMicroversionId: string;
+  // There are more fields, but they are not needed here
+}
+
+export interface ResolveReferencesResponse {
+  resolvedReferences: DrawingReference[];
 }
 


### PR DESCRIPTION
Added 2 new scripts for checking if drawings need updates:
- detect-if-single-drawing-needs-update - will check one drawing to see if it needs an update
- detect-if-workspace-contains-drawings-needing-update - will check all the drawings in a workspace to see if any of them need an update

Added code to check the new isDangling field that was recently added to inspection symbols.

Added code to parse the new output string returned by the modify/status API, which contains clear results for modify actions.

Note that I will need to change launch.json to have production (cad.onshape.com) URLs instead of Demo-C URLs before this is merged.  I could not use production URLs now because the needed API changes are not on production yet.  So this will not be merged until 1.189 is released.